### PR TITLE
Wasabi.js cleaned scope, and removed inject contracts as global variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ wasabi init
 ## Configure
 Wasabi can be configured to use an account on the RPC OR provide a `private_key` to sign contract deployment transactions locally. Local signing is helpful when using Infura or other public RPC nodes. If a `private_key` is provided, the `from` address will be ignored, and wasabi will perform client side signing for deployment transactions.
 
-```json
+```js
 {
     // http endpoint for JSON RPC e.g. http://localhost:8545
     "host": "http://localhost:8545",

--- a/README.md
+++ b/README.md
@@ -19,23 +19,23 @@ wasabi init
 ## Configure
 Wasabi can be configured to use an account on the RPC OR provide a `private_key` to sign contract deployment transactions locally. Local signing is helpful when using Infura or other public RPC nodes. If a `private_key` is provided, the `from` address will be ignored, and wasabi will perform client side signing for deployment transactions.
 
-```
+```json
 {
     // http endpoint for JSON RPC e.g. http://localhost:8545
-	"host": "http://localhost:8545",
+    "host": "http://localhost:8545",
     // Maximum gas budget for a contract
     "max_gas": "100000000",
     // Deploy contract from address
     "from": "0x00000000000000000000",
     // Use private key to sign transactions in wasabi
-	//"private_key": "YOUR_PRIVATE_KEY",
+    //"private_key": "YOUR_PRIVATE_KEY",
     // Path to contract files
-	"contracts": ["contracts/SimpleStorage.sol"]
+    "contracts": ["contracts/SimpleStorage.sol"]
 }
 ```
 
 ## Compile
-Complile solidity contracts listed in config and compile check for errors.
+Complile solidity contracts listed in config and compile check for errors. Wasabi uses 'solc' for copiling solidity contracts.
 ```
 wasabi compile
 ```
@@ -45,6 +45,9 @@ Deploy solidity contracts through the RPC node provided in config.
 ```
 wasabi deploy
 ```
+
+### Developing Dapps
+On successful `wasabi deploy`, the contract address and ABI are made available in `app/contracts.json`. A scaffolded JS in also available in `app/wasabi.js`, which can be used in Dapps to populate `web3` contracts instances using `contracts.json`.
 
 ## Demo
 Run a http server running at `http://localhost:8888` hosting static files in the `app` directory to test your Dapp.

--- a/static/wasabi.js
+++ b/static/wasabi.js
@@ -1,38 +1,40 @@
-function startApp () {
-    var xmlHttp = new XMLHttpRequest();
-    xmlHttp.onreadystatechange = function() { 
-        if (xmlHttp.readyState == 4 && xmlHttp.status == 200) {
-            var wasabi = JSON.parse(xmlHttp.responseText);
-            wasabi.forEach(function (contract, index) {
-                var definition = web3.eth.contract(contract.abi);
-                var c = definition.at(contract.address);
-                window[contract.name] = {
-                    deployed: function () {
-                        return c;
-                    },
-                    at: function (address) {
-                        return definition.at(address);
-                    }
-                };
-            });
+(function () {
+    function startApp () {
+        var xmlHttp = new XMLHttpRequest();
+        xmlHttp.onreadystatechange = function() { 
+            if (xmlHttp.readyState == 4 && xmlHttp.status == 200) {
+                var wasabi = JSON.parse(xmlHttp.responseText);
+                wasabi.forEach(function (contract, index) {
+                    var definition = web3.eth.contract(contract.abi);
+                    var c = definition.at(contract.address);
+                    window[contract.name] = {
+                        deployed: function () {
+                            return c;
+                        },
+                        at: function (address) {
+                            return definition.at(address);
+                        }
+                    };
+                });
+            }
         }
+        xmlHttp.open("GET", "/contracts.json", true);
+        xmlHttp.send(null);
     }
-    xmlHttp.open("GET", "/contracts.json", true);
-    xmlHttp.send(null);
-}
 
-window.addEventListener('load', function() {
-    window.addEventListener('web3-loaded', startApp());
-    // Checking if Web3 has been injected by the browser (Mist/MetaMask)
-    if (typeof web3 !== 'undefined') {
-        // Use Mist/MetaMask's provider
-        window.web3 = new Web3(web3.currentProvider);
-        var event = new Event('web3-loaded');
-        window.dispatchEvent(event);
-    } else {
-        console.error("Web3 is undefined: Your browser does not support dApps. Please use Mist, Metamask of comparable dApp explorer.");
-        var event = new Event('web3-failed');
-        window.dispatchEvent(event);
-        return;
-    }
-});
+    window.addEventListener('load', function() {
+        window.addEventListener('web3-loaded', startApp());
+        // Checking if Web3 has been injected by the browser (Mist/MetaMask)
+        if (typeof web3 !== 'undefined') {
+            // Use Mist/MetaMask's provider
+            window.web3 = new Web3(web3.currentProvider);
+            var event = new Event('web3-loaded');
+            window.dispatchEvent(event);
+        } else {
+            console.error("Web3 is undefined: Your browser does not support dApps. Please use Mist, Metamask of comparable dApp explorer.");
+            var event = new Event('web3-failed');
+            window.dispatchEvent(event);
+            return;
+        }
+    });
+})();

--- a/static/wasabi.js
+++ b/static/wasabi.js
@@ -1,13 +1,14 @@
 (function () {
-    function startApp () {
+    Wasabi = {};
+    function initWasabi () {
         var xmlHttp = new XMLHttpRequest();
         xmlHttp.onreadystatechange = function() { 
             if (xmlHttp.readyState == 4 && xmlHttp.status == 200) {
-                var wasabi = JSON.parse(xmlHttp.responseText);
-                wasabi.forEach(function (contract, index) {
+                var config = JSON.parse(xmlHttp.responseText);
+                config.forEach(function (contract, index) {
                     var definition = web3.eth.contract(contract.abi);
                     var c = definition.at(contract.address);
-                    window[contract.name] = {
+                    Wasabi[contract.name] = {
                         deployed: function () {
                             return c;
                         },
@@ -23,7 +24,7 @@
     }
 
     window.addEventListener('load', function() {
-        window.addEventListener('web3-loaded', startApp());
+        window.addEventListener('web3-loaded', initWasabi());
         // Checking if Web3 has been injected by the browser (Mist/MetaMask)
         if (typeof web3 !== 'undefined') {
             // Use Mist/MetaMask's provider


### PR DESCRIPTION
`Wasabi` will be the primary namespace under which deployed contracts and their ABI based instances will be populated. This is a resolution for #7.